### PR TITLE
Use full path when including kernels

### DIFF
--- a/src/gp_functions.jl
+++ b/src/gp_functions.jl
@@ -973,7 +973,7 @@ function include_kernel(kernel_name::AbstractString)
     if !occursin("_kernel", kernel_name)
         kernel_name *= "_kernel"
     end
-    return include(pathof(GLOM) * kernel_name * ".jl")
+    return include(joinpath(pathof(GLOM),"..","kernels", kernel_name * ".jl"))
 end
 
 

--- a/src/gp_functions.jl
+++ b/src/gp_functions.jl
@@ -973,7 +973,7 @@ function include_kernel(kernel_name::AbstractString)
     if !occursin("_kernel", kernel_name)
         kernel_name *= "_kernel"
     end
-    return include(joinpath(pathof(GLOM),"..","kernels", kernel_name * ".jl"))
+    return include(joinpath(pathof(GPLinearODEMaker),"..","kernels", kernel_name * ".jl"))
 end
 
 

--- a/src/gp_functions.jl
+++ b/src/gp_functions.jl
@@ -973,7 +973,7 @@ function include_kernel(kernel_name::AbstractString)
     if !occursin("_kernel", kernel_name)
         kernel_name *= "_kernel"
     end
-    return include(pathof(GLOM)[1:end-19] * kernel_name * ".jl")
+    return include(pathof(GLOM) * kernel_name * ".jl")
 end
 
 


### PR DESCRIPTION
Otherwise error when using from another package.  
N.B. I haven't testing that this doesn't break things